### PR TITLE
SFX-421: Update Search Driver to use area and collection

### DIFF
--- a/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
@@ -3,6 +3,12 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@groupby/elements-core';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 import { Record, Results, Request as SearchRequest } from '@groupby/elements-search-plugin';
 import {
+  Record,
+  Results,
+  Request as SearchRequest,
+  QueryConfiguration,
+} from '@sfx/search-plugin';
+import {
   SEARCH_REQUEST,
   SEARCH_RESPONSE,
   SEARCH_ERROR,
@@ -114,10 +120,10 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
   /**
    * Sends a search request using the GroupBy API.
    *
-   * @param query the query to send.
+   * @param request The request object that contains the search term and any extra parameters.
    */
-  sendSearchApiRequest(query: string): Promise<SearchResponseSection<P>> {
-    const fullQuery = { ...this.defaultSearchConfig, query };
+  sendSearchApiRequest(request: Partial<SearchRequest>): Promise<SearchResponseSection<P>> {
+    const fullQuery = { ...this.defaultSearchConfig, ...request };
     return this.core.search.search(fullQuery)
       .then(this.searchCallback);
   }

--- a/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
@@ -91,7 +91,7 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
   }
 
   /**
-   * Performs a search with the given search term and configurations
+   * Performs a search with the given search term and configuration
    * and emits the result through an event. The result is emitted in a
    * [[SEARCH_RESPONSE]] event. If the search fails for any
    * reason, a [[SEARCH_ERROR]] is dispatched with the error.

--- a/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
@@ -91,8 +91,8 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
   }
 
   /**
-   * Performs a search with the given search term and emits the result
-   * through an event. The result is emitted in a
+   * Performs a search with the given search term and configurations
+   * and emits the result through an event. The result is emitted in a
    * [[SEARCH_RESPONSE]] event. If the search fails for any
    * reason, a [[SEARCH_ERROR]] is dispatched with the error.
    *

--- a/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
@@ -3,12 +3,6 @@ import { Plugin, PluginRegistry, PluginMetadata } from '@groupby/elements-core';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 import { Record, Results, Request as SearchRequest } from '@groupby/elements-search-plugin';
 import {
-  Record,
-  Results,
-  Request as SearchRequest,
-  QueryConfiguration,
-} from '@sfx/search-plugin';
-import {
   SEARCH_REQUEST,
   SEARCH_RESPONSE,
   SEARCH_ERROR,
@@ -105,8 +99,8 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
    * @param event the event whose payload is the search term.
    */
   fetchSearchData(event: CustomEvent<SearchRequestPayload>): void {
-    const { query, group } = event.detail;
-    this.sendSearchApiRequest(query)
+    const { query, group, config } = event.detail;
+    this.sendSearchApiRequest({ query, ...config })
       .then((results) => {
         const payload: SearchResponsePayload<P> = { results, group };
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE, payload);

--- a/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -150,8 +150,11 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('sendSearchApiRequest()', () => {
-    it('should forward the query to the search plugin', () => {
+    it('should forward the query and any config options to the search plugin', () => {
       const query = 'search term';
+      const area = 'area';
+      const collection = 'collection';
+      const request = { query, area, collection };
       const results = Promise.resolve({ search: 'results' });
       const searchCallbackResponse = {
         originalResponse: { full: 'response' },
@@ -162,10 +165,12 @@ describe('SearchDriverPlugin', () => {
       search.withArgs({
         fields: ['*'],
         query,
+        area,
+        collection,
       }).returns(results);
       searchDriverPlugin.core = { search: { search } };
 
-      const result = searchDriverPlugin.sendSearchApiRequest(query);
+      const result = searchDriverPlugin.sendSearchApiRequest(request);
 
       return expect(result).to.eventually.equal(searchCallbackResponse);
     });

--- a/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -108,7 +108,7 @@ describe('SearchDriverPlugin', () => {
       expect(sendSearchApiRequest).to.be.calledWith(request);
     });
 
-    it('should search with any extra config options', () => {
+    it('should search with all provided config options', () => {
       const query = 'search term';
       const area = 'area';
       const collection = 'collection';
@@ -167,7 +167,7 @@ describe('SearchDriverPlugin', () => {
   });
 
   describe('sendSearchApiRequest()', () => {
-    it('should forward the query and any config options to the search plugin', () => {
+    it('should forward the query and all provided config options to the search plugin', () => {
       const query = 'search term';
       const area = 'area';
       const collection = 'collection';

--- a/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -97,6 +97,7 @@ describe('SearchDriverPlugin', () => {
 
     it('should search with the given search term', () => {
       const query = 'search term';
+      const request = { query };
       sendSearchApiRequest.resolves();
       searchDriverPlugin.core = {
         [eventsPluginName]: { dispatchEvent: () => {} },
@@ -104,7 +105,23 @@ describe('SearchDriverPlugin', () => {
 
       searchDriverPlugin.fetchSearchData({ detail: { query } } as any);
 
-      expect(sendSearchApiRequest).to.be.calledWith(query);
+      expect(sendSearchApiRequest).to.be.calledWith(request);
+    });
+
+    it('should search with any extra config options', () => {
+      const query = 'search term';
+      const area = 'area';
+      const collection = 'collection';
+      const config = { area, collection };
+      const request = { query, area, collection };
+      sendSearchApiRequest.resolves();
+      searchDriverPlugin.core = {
+        [eventsPluginName]: { dispatchEvent: () => {} },
+      };
+
+      searchDriverPlugin.fetchSearchData({ detail: { query, config } } as any);
+
+      expect(sendSearchApiRequest).to.be.calledWith(request);
     });
 
     it('should dispatch an event with the results and the group if present', (done) => {


### PR DESCRIPTION
Search request events are able to pass an `area` and `collection` to the SearchDriverPlugin. Updating the plugin to pass these to the search caller. 