### PR TITLE
ELE-519: Make Search and SAYT products response structure identical

### DIFF
--- a/packages/@groupby/elements-cache-driver-plugin/package.json
+++ b/packages/@groupby/elements-cache-driver-plugin/package.json
@@ -25,6 +25,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#710e5545802bcc4929b253add2677bd22561a758"
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065"
   }
 }

--- a/packages/@groupby/elements-cache-plugin/package.json
+++ b/packages/@groupby/elements-cache-plugin/package.json
@@ -25,6 +25,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#710e5545802bcc4929b253add2677bd22561a758"
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065"
   }
 }

--- a/packages/@groupby/elements-sayt-driver-plugin/package.json
+++ b/packages/@groupby/elements-sayt-driver-plugin/package.json
@@ -26,6 +26,6 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#710e5545802bcc4929b253add2677bd22561a758"
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065"
   }
 }

--- a/packages/@groupby/elements-search-driver-plugin/package.json
+++ b/packages/@groupby/elements-search-driver-plugin/package.json
@@ -25,6 +25,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#710e5545802bcc4929b253add2677bd22561a758"
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065"
   }
 }

--- a/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
+++ b/packages/@groupby/elements-search-driver-plugin/src/search-driver-plugin.ts
@@ -9,7 +9,6 @@ import {
   ProductTransformer,
   SearchRequestPayload,
   SearchResponsePayload,
-  SearchResponseSection,
   SearchErrorPayload,
 } from '@groupby/elements-events';
 
@@ -102,7 +101,7 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
     const { query, group, config } = event.detail;
     this.sendSearchApiRequest({ query, ...config })
       .then((results) => {
-        const payload: SearchResponsePayload<P> = { results, group };
+        const payload: SearchResponsePayload<P> = { ...results, group };
         this.core[this.eventsPluginName].dispatchEvent(SEARCH_RESPONSE, payload);
         if (this.core.cache) this.core.cache.set(`${SEARCH_RESPONSE}::${group}`, payload);
       })
@@ -117,7 +116,7 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
    *
    * @param request The request object that contains the search term and any extra parameters.
    */
-  sendSearchApiRequest(request: Partial<SearchRequest>): Promise<SearchResponseSection<P>> {
+  sendSearchApiRequest(request: Partial<SearchRequest>): Promise<SearchResponsePayload<P>> {
     const fullQuery = { ...this.defaultSearchConfig, ...request };
     return this.core.search.search(fullQuery)
       .then(this.searchCallback);
@@ -131,7 +130,7 @@ export default class SearchDriverPlugin<P = Record> implements Plugin {
    * @param response An object containing the original query and product records.
    * @returns An object containing the query and an array of valid simplified products.
    */
-  searchCallback(response: Results): SearchResponseSection<P> {
+  searchCallback(response: Results): SearchResponsePayload<P> {
     const { records } = response;
     const mappedRecords = records.map(this.transformProduct).filter(Boolean);
 

--- a/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -134,7 +134,7 @@ describe('SearchDriverPlugin', () => {
 
     it('should dispatch an event with the results and the group if present', (done) => {
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE, { results, group });
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE, { ...results, group });
         done();
       });
       group = 'group';
@@ -148,7 +148,7 @@ describe('SearchDriverPlugin', () => {
 
     it('should send an undefined group if one is not provided', (done) => {
       const dispatchEvent = spy(() => {
-        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE, { results, group });
+        expect(dispatchEvent).to.be.calledWith(SEARCH_RESPONSE, { ...results, group });
         done();
       });
       sendSearchApiRequest.resolves(results);

--- a/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
+++ b/packages/@groupby/elements-search-driver-plugin/test/unit/common/search-driver-plugin.test.ts
@@ -129,7 +129,7 @@ describe('SearchDriverPlugin', () => {
       searchDriverPlugin.fetchSearchData({ detail: { query, ...config } } as any);
 
       return expect(Promise.resolve(set))
-        .to.be.eventually.calledOnceWith(`${SEARCH_RESPONSE}::${group}`, { results, group });
+        .to.be.eventually.calledOnceWith(`${SEARCH_RESPONSE}::${group}`, { ...results, group });
     });
 
     it('should dispatch an event with the results and the group if present', (done) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,9 +89,9 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@groupby/elements-events@groupby/elements-events#710e5545802bcc4929b253add2677bd22561a758":
+"@groupby/elements-events@groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065":
   version "0.0.0"
-  resolved "https://codeload.github.com/groupby/elements-events/tar.gz/710e5545802bcc4929b253add2677bd22561a758"
+  resolved "https://codeload.github.com/groupby/elements-events/tar.gz/66ab6ebc4b2786f65ffc8ae64d3facbd2e628065"
   dependencies:
     groupby-api "^2.6.2"
     sayt "^0.1.9"


### PR DESCRIPTION
Updating the products responses from Search and Sayt to have identical payloads. Will make writing code and dealing with the responses from the drivers easier in the future. 