### PR TITLE
Restore build final cache before linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - restore_cache: *yarn_cache
+      - restore_cache: *build_final_cache_partial
       - run: *extract_build_archive
       - run: *git_submodule_install
       - run: *yarn_install


### PR DESCRIPTION
This prevents the linter from complaining about no-unresolved.