### PR TITLE
ELE-247: Add quick start package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_search_plugin-
       - run: *extract_build_archive
       - restore_cache:
-          key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_cache-plugin-
+          key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_cache_plugin-
       - run: *extract_build_archive
       - restore_cache:
           key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_sayt_driver_plugin-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,9 @@ jobs:
       - restore_cache:
           key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_cache_driver_plugin-
       - run: *extract_build_archive
+      - restore_cache:
+          key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-build_quickstart-
+      - run: *extract_build_archive
       - run: *archive_build
       - save_cache:
           key: build_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }}-{{ checksum "../workflow-start" }}-all-{{ epoch }}
@@ -291,10 +294,20 @@ workflows:
           requires:
             - collect_independent_builds
       - collect_builds:
-          name: build_final
+          name: build_all_plugins
           requires:
             - build_sayt_driver_plugin
             - build_search_driver_plugin
+            - build_cache_driver_plugin
+
+      - build:
+          name: build_quickstart
+          requires:
+            - build_all_plugins
+      - collect_builds:
+          name: build_final
+          requires:
+            - build_quickstart
 
       - unit_test:
           name: unit_test_core
@@ -319,6 +332,9 @@ workflows:
           <<: *requires_build_final
       - unit_test:
           name: unit_test_cache_driver_plugin
+          <<: *requires_build_final
+      - unit_test:
+          name: unit_test_quickstart
           <<: *requires_build_final
 
       - unit_test_browser:
@@ -345,6 +361,9 @@ workflows:
       - unit_test_browser:
           name: unit_test_browser_cache_driver_plugin
           <<: *requires_build_final
+      - unit_test_browser:
+          name: unit_test_browser_quickstart
+          <<: *requires_build_final
       - unit_test_final:
           requires:
             - unit_test_core
@@ -355,6 +374,7 @@ workflows:
             - unit_test_sayt_driver_plugin
             - unit_test_search_driver_plugin
             - unit_test_cache_driver_plugin
+            - unit_test_quickstart
             - unit_test_browser_core
             - unit_test_browser_dom_events_plugin
             - unit_test_browser_sayt_plugin
@@ -363,6 +383,7 @@ workflows:
             - unit_test_browser_sayt_driver_plugin
             - unit_test_browser_search_driver_plugin
             - unit_test_browser_cache_driver_plugin
+            - unit_test_browser_quickstart
 
       - lint:
           requires:

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "workspaces": [
     "packages/@groupby/elements-core",
     "packages/@groupby/elements-dom-events-plugin",
-    "packages/@groupby/elements-!(*-driver-plugin)",
-    "packages/@groupby/*"
+    "packages/@groupby/elements-!(*-driver-plugin|quickstart)",
+    "packages/@groupby/elements-!(quickstart)",
+    "packages/@groupby/elements-quickstart"
   ],
   "scripts": {
     "bundle": "webpack",

--- a/packages/@groupby/elements-cache-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-cache-driver-plugin/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Added
-- Add options to the `CacheDriverPlugin`.
+- ELE-247: Add options to the `CacheDriverPlugin`.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/packages/@groupby/elements-cache-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-cache-driver-plugin/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Added
-- ELE-247: Add options to the `CacheDriverPlugin`.
+- ELE-247: Taught `CacheDriverPlugin` to accept options for consistency with other plugins.
+  No options are currently recognized.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/packages/@groupby/elements-cache-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-cache-driver-plugin/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- Add options to the `CacheDriverPlugin`.
+
 ## [0.1.0] - 2019-11-28
 ### Added
 - SFX-158: Added the `CacheDriverPlugin` module.

--- a/packages/@groupby/elements-cache-driver-plugin/src/cache-driver-plugin.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/src/cache-driver-plugin.ts
@@ -25,6 +25,7 @@ export default class CacheDriverPlugin implements Plugin {
    * callbacks.
    */
   constructor(options: Partial<CacheDriverOptions> = {}) {
+    this.options = { ...this.options, ...options };
     this.handleRequest = this.handleRequest.bind(this);
   }
 

--- a/packages/@groupby/elements-cache-driver-plugin/src/cache-driver-plugin.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/src/cache-driver-plugin.ts
@@ -13,6 +13,8 @@ export default class CacheDriverPlugin implements Plugin {
     };
   }
 
+  options: CacheDriverOptions = {};
+
   /**
    * A reference to the registry of plugins for internal use.
    */
@@ -22,7 +24,7 @@ export default class CacheDriverPlugin implements Plugin {
    * Constructs a new instance of this plugin and binds the necessary
    * callbacks.
    */
-  constructor() {
+  constructor(options: Partial<CacheDriverOptions> = {}) {
     this.handleRequest = this.handleRequest.bind(this);
   }
 
@@ -60,3 +62,6 @@ export default class CacheDriverPlugin implements Plugin {
     this.core.dom_events.dispatchEvent(returnEvent, payload);
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CacheDriverOptions {}

--- a/packages/@groupby/elements-cache-driver-plugin/src/index.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/src/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as CacheDriverPlugin } from './cache-driver-plugin';
+export { default as CacheDriverPlugin, CacheDriverOptions } from './cache-driver-plugin';

--- a/packages/@groupby/elements-cache-driver-plugin/test/unit/common/cache-driver-plugin.test.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/test/unit/common/cache-driver-plugin.test.ts
@@ -19,6 +19,14 @@ describe('CacheDriverPlugin', () => {
     });
   });
 
+  describe('constructor()', () => {
+    it('should create a new instance of the CacheDriverPlugin with default options', () => {
+      const defaultOptions = {};
+
+      expect(cacheDriverPlugin.options).to.deep.equal(defaultOptions);
+    });
+  });
+
   describe('register()', () => {
     it('should save the plugin registry for future use', () => {
       const registry: any = { a: 1, b: 2 };

--- a/packages/@groupby/elements-cache-driver-plugin/test/unit/common/cache-driver-plugin.test.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/test/unit/common/cache-driver-plugin.test.ts
@@ -20,10 +20,22 @@ describe('CacheDriverPlugin', () => {
   });
 
   describe('constructor()', () => {
-    it('should create a new instance of the CacheDriverPlugin with default options', () => {
-      const defaultOptions = {};
+    let defaultOptions;
 
+    beforeEach(() => {
+      defaultOptions = {};
+    });
+
+    it('should create a new instance of the CacheDriverPlugin with default options', () => {
       expect(cacheDriverPlugin.options).to.deep.equal(defaultOptions);
+    });
+
+    it('should combine the default and instance options', () => {
+      const options = { a: 'a' };
+
+      cacheDriverPlugin = new CacheDriverPlugin(options);
+
+      expect(cacheDriverPlugin.options).to.deep.equal({ ...defaultOptions, ...options });
     });
   });
 

--- a/packages/@groupby/elements-cache-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/test/unit/common/index.test.ts
@@ -1,7 +1,7 @@
 import { AssertTypesEqual, expect } from '../../utils';
 import {
   CacheDriverPlugin as CacheDriverPluginExport,
-  CacheDriverOptions as CacheDriverOptionsExport
+  CacheDriverOptions as CacheDriverOptionsExport,
 } from '../../../src';
 import CacheDriverPlugin, { CacheDriverOptions } from '../../../src/cache-driver-plugin';
 

--- a/packages/@groupby/elements-cache-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-cache-driver-plugin/test/unit/common/index.test.ts
@@ -1,9 +1,17 @@
-import { expect } from '../../utils';
-import { CacheDriverPlugin as CacheDriverPluginExport } from '../../../src';
-import CacheDriverPlugin from '../../../src/cache-driver-plugin';
+import { AssertTypesEqual, expect } from '../../utils';
+import {
+  CacheDriverPlugin as CacheDriverPluginExport,
+  CacheDriverOptions as CacheDriverOptionsExport
+} from '../../../src';
+import CacheDriverPlugin, { CacheDriverOptions } from '../../../src/cache-driver-plugin';
 
 describe('Entry point', () => {
   it('should export the CacheDriverPlugin', () => {
     expect(CacheDriverPluginExport).to.equal(CacheDriverPlugin);
+  });
+
+  it('should export the CacheDriverOptions interface', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const test: AssertTypesEqual<CacheDriverOptionsExport, CacheDriverOptions> = true;
   });
 });

--- a/packages/@groupby/elements-quickstart/CHANGELOG.md
+++ b/packages/@groupby/elements-quickstart/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/@groupby/elements-quickstart/CHANGELOG.md
+++ b/packages/@groupby/elements-quickstart/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] [minor]
 ### Added
 - ELE-247: Add quick start function. This function instantiates Core
   and registers the following plugins with provided configuration:

--- a/packages/@groupby/elements-quickstart/CHANGELOG.md
+++ b/packages/@groupby/elements-quickstart/CHANGELOG.md
@@ -3,3 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- ELE-247: Add quick start function. This function instantiates Core
+  and registers the following plugins with provided configuration:
+  - `cache`
+  - `cache_driver`
+  - `dom_events`
+  - `sayt`
+  - `sayt_driver`
+  - `search`
+  - `search_driver`

--- a/packages/@groupby/elements-quickstart/README.md
+++ b/packages/@groupby/elements-quickstart/README.md
@@ -1,0 +1,1 @@
+# GroupBy Elements Quick Start

--- a/packages/@groupby/elements-quickstart/README.md
+++ b/packages/@groupby/elements-quickstart/README.md
@@ -1,1 +1,45 @@
 # GroupBy Elements Quick Start
+
+This package contains the GB Elements quick start pack.
+
+## Usage
+
+To use the starter pack, call the `quickStart` function with a customer ID.
+For example:
+
+```js
+const core = quickStart({
+  customerId: 'mycustomerid',  // replace with your customer ID
+  productTransformer: (product) => { /* ... */ }, // optional but recommended
+  pluginOptions: {             // optional
+    // ...
+  },
+});
+```
+
+The `quickStart` function will return an instance of Elements Core
+with all of the Elements plugins registered.
+
+### Options
+
+The `quickStart` function accepts an options object to configure the plugins.
+
+* `customerId`: **Required.** This is your GroupBy customer ID. It will
+  be passed to `SaytPlugin` and `SearchPlugin`.
+* `productTransformer`: Optional, but recommended.
+  This is a function that transforms the product records received
+  from the GroupBy API into an Elements Product object. This will be
+  passed to the `SaytDriverPlugin` and `SearchDriverPlugin`.
+* `pluginOptions`: Optional. This is an object that allows you to configure individual plugins.
+  The object has as keys the plugin names (`search`, `search_driver`, etc.)
+  and as values the corresponding plugin option objects.
+  All properties supported by this object are optional.
+
+  Supported keys are:
+  * `cache`
+  * `cache_driver`
+  * `dom_events`
+  * `sayt`
+  * `sayt_driver`
+  * `search`
+  * `search_driver`

--- a/packages/@groupby/elements-quickstart/README.md
+++ b/packages/@groupby/elements-quickstart/README.md
@@ -31,8 +31,8 @@ The `quickStart` function accepts an options object to configure the plugins.
   from the GroupBy API into an Elements Product object. This will be
   passed to the `SaytDriverPlugin` and `SearchDriverPlugin`.
 * `pluginOptions`: Optional. This is an object that allows you to configure individual plugins.
-  The object has as keys the plugin names (`search`, `search_driver`, etc.)
-  and as values the corresponding plugin option objects.
+  The object provides plugin options, where the keys are the plugin names (`search`, `search_driver`, etc.),
+  and the values are the corresponding plugin options.
   All properties supported by this object are optional.
 
   Supported keys are:

--- a/packages/@groupby/elements-quickstart/karma.conf.js
+++ b/packages/@groupby/elements-quickstart/karma.conf.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../karma.conf.js');

--- a/packages/@groupby/elements-quickstart/package.json
+++ b/packages/@groupby/elements-quickstart/package.json
@@ -30,6 +30,7 @@
     "@groupby/elements-cache-plugin": "^0.1.0",
     "@groupby/elements-core": "^0.1.0",
     "@groupby/elements-dom-events-plugin": "^0.1.0",
+    "@groupby/elements-events": "^0.1.0",
     "@groupby/elements-sayt-driver-plugin": "^0.1.0",
     "@groupby/elements-sayt-plugin": "^0.1.0",
     "@groupby/elements-search-driver-plugin": "^0.1.0",

--- a/packages/@groupby/elements-quickstart/package.json
+++ b/packages/@groupby/elements-quickstart/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@groupby/elements-quickstart",
+  "version": "0.1.0",
+  "description": "GroupBy Elements Quick Start Helper",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "esnext/index.js",
+  "scripts": {
+    "build": "../../../scripts/build.sh",
+    "dev": "nodemon --config ../../../nodemon.json --exec npm run build",
+    "test": "nyc mocha",
+    "tdd": "nodemon --config ../../../nodemon.test.json --exec npm test",
+    "test:browser": "karma start karma.conf.js",
+    "tdd:browser": "karma start karma.conf.js --no-single-run",
+    "lint:scripts": "eslint ./src/ --ext .ts --plugin only-warn",
+    "lint:scripts:fix": "eslint ./src/ --fix --ext .ts --plugin only-warn",
+    "lint:tests": "eslint ./test/ --ext .ts --no-eslintrc -c ../../../scripts/config/eslint/test/.eslintrc.js --plugin only-warn",
+    "lint:tests:fix": "eslint ./test/ --ext .ts --fix --no-eslintrc -c ../../../scripts/config/eslint/test/.eslintrc.js --plugin only-warn"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/groupby/elements-logic.git",
+    "directory": "packages/@groupby/elements-quickstart"
+  },
+  "author": "GroupBy Inc",
+  "license": "MIT",
+  "sideEffects": false,
+  "dependencies": {
+    "@groupby/elements-cache-driver-plugin": "^0.1.0",
+    "@groupby/elements-cache-plugin": "^0.1.0",
+    "@groupby/elements-core": "^0.1.0",
+    "@groupby/elements-dom-events-plugin": "^0.1.0",
+    "@groupby/elements-sayt-driver-plugin": "^0.1.0",
+    "@groupby/elements-sayt-plugin": "^0.1.0",
+    "@groupby/elements-search-driver-plugin": "^0.1.0",
+    "@groupby/elements-search-plugin": "^0.1.0"
+  }
+}

--- a/packages/@groupby/elements-quickstart/src/index.ts
+++ b/packages/@groupby/elements-quickstart/src/index.ts
@@ -1,0 +1,1 @@
+export { default as quickStart, QuickStartOptions } from './quick-start';

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,5 +1,19 @@
+import { CacheDriverPlugin } from '@groupby/elements-cache-driver-plugin';
+import { CachePlugin } from '@groupby/elements-cache-plugin';
 import { Core } from '@groupby/elements-core';
+import { DomEventsPlugin } from '@groupby/elements-dom-events-plugin';
+import { SaytDriverPlugin } from '@groupby/elements-sayt-driver-plugin';
+import { SaytPlugin } from '@groupby/elements-sayt-plugin';
+import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
+import { SearchPlugin } from '@groupby/elements-search-plugin';
 
 export default function quickStart(): Core {
+  const cacheDriverPlugin = new CacheDriverPlugin();
+  const cachePlugin = new CachePlugin();
+  const domEventsPlugin = new DomEventsPlugin();
+  const saytDriverPlugin = new SaytDriverPlugin();
+  const saytPlugin = new SaytPlugin();
+  const searchDriverPlugin = new SearchDriverPlugin();
+  const searchPlugin = new SearchPlugin({} as any);
   return new Core();
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -61,9 +61,9 @@ export default function quickStart<P>({
   const cachePlugin = new CachePlugin(cache);
   const domEventsPlugin = new DomEventsPlugin(dom_events);
   const saytDriverPlugin = new SaytDriverPlugin({ ...wrappedProductTransformer, ...sayt_driver });
-  const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
+  const saytPlugin = new SaytPlugin({ subdomain: customerId, ...sayt });
   const searchDriverPlugin = new SearchDriverPlugin({ ...wrappedProductTransformer, ...search_driver });
-  const searchPlugin = new SearchPlugin({ ...search, customerId });
+  const searchPlugin = new SearchPlugin({ customerId, ...search });
 
   core.register([
     cacheDriverPlugin,

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,0 +1,2 @@
+export default function quickStart(): void {
+}

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -3,11 +3,12 @@ import { CachePlugin, CachePluginOptions } from '@groupby/elements-cache-plugin'
 import { Core } from '@groupby/elements-core';
 import { DomEventsPlugin, DomEventsPluginOptions } from '@groupby/elements-dom-events-plugin';
 import { ProductTransformer } from '@groupby/elements-events';
-import { SaytDriverPlugin } from '@groupby/elements-sayt-driver-plugin';
+import { SaytDriverPlugin, SaytDriverOptions } from '@groupby/elements-sayt-driver-plugin';
 import { SaytPlugin } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin, SearchPluginOptions } from '@groupby/elements-search-plugin';
 import { SaytConfig } from 'sayt';
+import {  } from '@groupby/elements-sayt-driver-plugin/dist/sayt-driver-plugin';
 
 export default function quickStart<P>({
   customerId,
@@ -16,6 +17,7 @@ export default function quickStart<P>({
     cache,
     dom_events,
     sayt,
+    sayt_driver,
     search, 
   } = {},
 }: QuickStartOptions<P>): Core {
@@ -23,7 +25,7 @@ export default function quickStart<P>({
   const cacheDriverPlugin = new CacheDriverPlugin();
   const cachePlugin = new CachePlugin(cache);
   const domEventsPlugin = new DomEventsPlugin(dom_events);
-  const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
+  const saytDriverPlugin = new SaytDriverPlugin({ ...sayt_driver, productTransformer });
   const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
   const searchPlugin = new SearchPlugin({ ...search, customerId });
@@ -48,6 +50,7 @@ export interface QuickStartOptions<P> {
     cache?: Partial<CachePluginOptions>;
     dom_events?: Partial<DomEventsPluginOptions>;
     sayt?: SaytConfig;
+    sayt_driver?: Partial<SaytDriverOptions<P>>;
     search?: Partial<SearchPluginOptions>;
   }
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -55,13 +55,14 @@ export default function quickStart<P>({
     search_driver,
   } = {},
 }: QuickStartOptions<P>): Core {
+  const wrappedProductTransformer = productTransformer ? { productTransformer } : {};
   const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin(cache_driver);
   const cachePlugin = new CachePlugin(cache);
   const domEventsPlugin = new DomEventsPlugin(dom_events);
-  const saytDriverPlugin = new SaytDriverPlugin({ productTransformer, ...sayt_driver });
+  const saytDriverPlugin = new SaytDriverPlugin({ ...wrappedProductTransformer, ...sayt_driver });
   const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
-  const searchDriverPlugin = new SearchDriverPlugin({ productTransformer, ...search_driver });
+  const searchDriverPlugin = new SearchDriverPlugin({ ...wrappedProductTransformer, ...search_driver });
   const searchPlugin = new SearchPlugin({ ...search, customerId });
 
   core.register([

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -8,6 +8,7 @@ import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin } from '@groupby/elements-search-plugin';
 
 export default function quickStart(): Core {
+  const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin();
   const cachePlugin = new CachePlugin();
   const domEventsPlugin = new DomEventsPlugin();
@@ -15,5 +16,16 @@ export default function quickStart(): Core {
   const saytPlugin = new SaytPlugin();
   const searchDriverPlugin = new SearchDriverPlugin();
   const searchPlugin = new SearchPlugin({} as any);
-  return new Core();
+
+  core.register([
+    cacheDriverPlugin,
+    cachePlugin,
+    domEventsPlugin,
+    saytDriverPlugin,
+    saytPlugin,
+    searchDriverPlugin,
+    searchPlugin,
+  ]);
+
+  return core;
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -56,9 +56,9 @@ export default function quickStart<P>({
   const cacheDriverPlugin = new CacheDriverPlugin(cache_driver);
   const cachePlugin = new CachePlugin(cache);
   const domEventsPlugin = new DomEventsPlugin(dom_events);
-  const saytDriverPlugin = new SaytDriverPlugin({ ...sayt_driver, productTransformer });
+  const saytDriverPlugin = new SaytDriverPlugin({ productTransformer, ...sayt_driver });
   const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
-  const searchDriverPlugin = new SearchDriverPlugin({ ...search_driver, productTransformer });
+  const searchDriverPlugin = new SearchDriverPlugin({ productTransformer, ...search_driver });
   const searchPlugin = new SearchPlugin({ ...search, customerId });
 
   core.register([

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -100,5 +100,5 @@ export interface QuickStartOptions<P> {
     search?: Partial<SearchPluginOptions>;
     /** Options for the Search Driver plugin. */
     search_driver?: Partial<SearchDriverOptions<P>>;
-  }
+  };
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -8,7 +8,6 @@ import { SaytPlugin } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin, SearchDriverOptions } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin, SearchPluginOptions } from '@groupby/elements-search-plugin';
 import { SaytConfig } from 'sayt';
-import {  } from '@groupby/elements-sayt-driver-plugin/dist/sayt-driver-plugin';
 
 export default function quickStart<P>({
   customerId,

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -5,7 +5,7 @@ import { DomEventsPlugin, DomEventsPluginOptions } from '@groupby/elements-dom-e
 import { ProductTransformer } from '@groupby/elements-events';
 import { SaytDriverPlugin, SaytDriverOptions } from '@groupby/elements-sayt-driver-plugin';
 import { SaytPlugin } from '@groupby/elements-sayt-plugin';
-import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
+import { SearchDriverPlugin, SearchDriverOptions } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin, SearchPluginOptions } from '@groupby/elements-search-plugin';
 import { SaytConfig } from 'sayt';
 import {  } from '@groupby/elements-sayt-driver-plugin/dist/sayt-driver-plugin';
@@ -18,7 +18,8 @@ export default function quickStart<P>({
     dom_events,
     sayt,
     sayt_driver,
-    search, 
+    search,
+    search_driver, 
   } = {},
 }: QuickStartOptions<P>): Core {
   const core = new Core();
@@ -27,7 +28,7 @@ export default function quickStart<P>({
   const domEventsPlugin = new DomEventsPlugin(dom_events);
   const saytDriverPlugin = new SaytDriverPlugin({ ...sayt_driver, productTransformer });
   const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
-  const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
+  const searchDriverPlugin = new SearchDriverPlugin({ ...search_driver, productTransformer });
   const searchPlugin = new SearchPlugin({ ...search, customerId });
 
   core.register([
@@ -52,5 +53,6 @@ export interface QuickStartOptions<P> {
     sayt?: SaytConfig;
     sayt_driver?: Partial<SaytDriverOptions<P>>;
     search?: Partial<SearchPluginOptions>;
+    search_driver?: Partial<SearchDriverOptions<P>>;
   }
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -9,8 +9,28 @@ import { SearchDriverPlugin, SearchDriverOptions } from '@groupby/elements-searc
 import { SearchPlugin, SearchPluginOptions } from '@groupby/elements-search-plugin';
 import { SaytConfig } from 'sayt';
 
+/**
+ * The GroupBy Elements quick start function.
+ * This function instantiates [[Core]] and registers a number of plugins.
+ *
+ * The plugins included are:
+ * - `cache`
+ * - `cache_driver
+ * - `dom_events`
+ * - `sayt`
+ * - `sayt_driver`
+ * - `search`
+ * - `search_driver`
+ *
+ * @param __namedParameters Options for plugin configuration.
+ * @returns An instance of Core with the above plugins configured and registered.
+ */
 export default function quickStart<P>({
+  /** The GroupBy customer ID to use. */
   customerId,
+  /**
+   * The function to use to transform a GroupBy Search API Record into an Elements Product.
+   */
   productTransformer,
   pluginOptions: {
     cache,

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -39,6 +39,7 @@ export default function quickStart<P>({
   pluginOptions: {
     /** Options for the Cache plugin. */
     cache,
+    /** Options for the Cache Driver plugin. */
     cache_driver,
     /** Options for the DOM Events plugin. */
     dom_events,
@@ -89,6 +90,7 @@ export interface QuickStartOptions<P> {
   pluginOptions?: {
     /** Options for the Cache plugin. */
     cache?: Partial<CachePluginOptions>;
+    /** Options for the Cache Driver plugin. */
     cache_driver?: Partial<CacheDriverOptions>;
     /** Options for the DOM Events plugin. */
     dom_events?: Partial<DomEventsPluginOptions>;

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -4,10 +4,9 @@ import { Core } from '@groupby/elements-core';
 import { DomEventsPlugin, DomEventsPluginOptions } from '@groupby/elements-dom-events-plugin';
 import { ProductTransformer } from '@groupby/elements-events';
 import { SaytDriverPlugin, SaytDriverOptions } from '@groupby/elements-sayt-driver-plugin';
-import { SaytPlugin } from '@groupby/elements-sayt-plugin';
+import { SaytPlugin, SaytPluginOptions } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin, SearchDriverOptions } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin, SearchPluginOptions } from '@groupby/elements-search-plugin';
-import { SaytConfig } from 'sayt';
 
 /**
  * The GroupBy Elements quick start function.

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -29,16 +29,27 @@ export default function quickStart<P>({
   /** The GroupBy customer ID to use. */
   customerId,
   /**
-   * The function to use to transform a GroupBy Search API Record into an Elements Product.
+   * The function to use to transform a GroupBy Search API Record
+   * into an Elements Product.
    */
   productTransformer,
+  /**
+   * Options to configure individual plugins.
+   * All keys are optional.
+   */
   pluginOptions: {
+    /** Options for the Cache plugin. */
     cache,
+    /** Options for the DOM Events plugin. */
     dom_events,
+    /** Options for the SAYT plugin. */
     sayt,
+    /** Options for the SAYT Driver plugin. */
     sayt_driver,
+    /** Options for the Search plugin. */
     search,
-    search_driver, 
+    /** Options for the Search Driver plugin. */
+    search_driver,
   } = {},
 }: QuickStartOptions<P>): Core {
   const core = new Core();
@@ -63,15 +74,30 @@ export default function quickStart<P>({
   return core;
 }
 
+/**
+ * Options for the quick start function.
+ */
 export interface QuickStartOptions<P> {
+  /** The GroupBy customer ID to pass to use. */
   customerId: string;
+  /**
+   * The function to use to transform a GroupBy Search API Record
+   * into an Elements Product.
+   */
   productTransformer?: ProductTransformer<P>;
+  /** Options to configure individual plugins. */
   pluginOptions?: {
+    /** Options for the Cache plugin. */
     cache?: Partial<CachePluginOptions>;
+    /** Options for the DOM Events plugin. */
     dom_events?: Partial<DomEventsPluginOptions>;
+    /** Options for the SAYT plugin. */
     sayt?: SaytConfig;
+    /** Options for the SAYT Driver plugin. */
     sayt_driver?: Partial<SaytDriverOptions<P>>;
+    /** Options for the Search plugin. */
     search?: Partial<SearchPluginOptions>;
+    /** Options for the Search Driver plugin. */
     search_driver?: Partial<SearchDriverOptions<P>>;
   }
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -97,7 +97,7 @@ export interface QuickStartOptions<P> {
     /** Options for the DOM Events plugin. */
     dom_events?: Partial<DomEventsPluginOptions>;
     /** Options for the SAYT plugin. */
-    sayt?: SaytPluginOptions;
+    sayt?: Partial<SaytPluginOptions>;
     /** Options for the SAYT Driver plugin. */
     sayt_driver?: Partial<SaytDriverOptions<P>>;
     /** Options for the Search plugin. */

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -7,13 +7,15 @@ import { SaytDriverPlugin } from '@groupby/elements-sayt-driver-plugin';
 import { SaytPlugin } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin } from '@groupby/elements-search-plugin';
+import { SaytConfig } from 'sayt';
 
 export default function quickStart<P>({
   customerId,
   productTransformer,
   pluginOptions: {
     cache,
-    dom_events
+    dom_events,
+    sayt,
   } = {},
 }: QuickStartOptions<P>): Core {
   const core = new Core();
@@ -21,7 +23,7 @@ export default function quickStart<P>({
   const cachePlugin = new CachePlugin(cache);
   const domEventsPlugin = new DomEventsPlugin(dom_events);
   const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
-  const saytPlugin = new SaytPlugin({ subdomain: customerId });
+  const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
   const searchPlugin = new SearchPlugin({ customerId });
 
@@ -44,5 +46,6 @@ export interface QuickStartOptions<P> {
   pluginOptions?: {
     cache?: Partial<CachePluginOptions>;
     dom_events?: Partial<DomEventsPluginOptions>;
+    sayt?: SaytConfig;
   }
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,4 +1,4 @@
-import { CacheDriverPlugin } from '@groupby/elements-cache-driver-plugin';
+import { CacheDriverPlugin, CacheDriverOptions } from '@groupby/elements-cache-driver-plugin';
 import { CachePlugin, CachePluginOptions } from '@groupby/elements-cache-plugin';
 import { Core } from '@groupby/elements-core';
 import { DomEventsPlugin, DomEventsPluginOptions } from '@groupby/elements-dom-events-plugin';
@@ -39,6 +39,7 @@ export default function quickStart<P>({
   pluginOptions: {
     /** Options for the Cache plugin. */
     cache,
+    cache_driver,
     /** Options for the DOM Events plugin. */
     dom_events,
     /** Options for the SAYT plugin. */
@@ -52,7 +53,7 @@ export default function quickStart<P>({
   } = {},
 }: QuickStartOptions<P>): Core {
   const core = new Core();
-  const cacheDriverPlugin = new CacheDriverPlugin();
+  const cacheDriverPlugin = new CacheDriverPlugin(cache_driver);
   const cachePlugin = new CachePlugin(cache);
   const domEventsPlugin = new DomEventsPlugin(dom_events);
   const saytDriverPlugin = new SaytDriverPlugin({ ...sayt_driver, productTransformer });
@@ -88,6 +89,7 @@ export interface QuickStartOptions<P> {
   pluginOptions?: {
     /** Options for the Cache plugin. */
     cache?: Partial<CachePluginOptions>;
+    cache_driver?: Partial<CacheDriverOptions>;
     /** Options for the DOM Events plugin. */
     dom_events?: Partial<DomEventsPluginOptions>;
     /** Options for the SAYT plugin. */

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -6,7 +6,7 @@ import { ProductTransformer } from '@groupby/elements-events';
 import { SaytDriverPlugin } from '@groupby/elements-sayt-driver-plugin';
 import { SaytPlugin } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
-import { SearchPlugin } from '@groupby/elements-search-plugin';
+import { SearchPlugin, SearchPluginOptions } from '@groupby/elements-search-plugin';
 import { SaytConfig } from 'sayt';
 
 export default function quickStart<P>({
@@ -16,6 +16,7 @@ export default function quickStart<P>({
     cache,
     dom_events,
     sayt,
+    search, 
   } = {},
 }: QuickStartOptions<P>): Core {
   const core = new Core();
@@ -25,7 +26,7 @@ export default function quickStart<P>({
   const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
   const saytPlugin = new SaytPlugin({ ...sayt, subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
-  const searchPlugin = new SearchPlugin({ customerId });
+  const searchPlugin = new SearchPlugin({ ...search, customerId });
 
   core.register([
     cacheDriverPlugin,
@@ -47,5 +48,6 @@ export interface QuickStartOptions<P> {
     cache?: Partial<CachePluginOptions>;
     dom_events?: Partial<DomEventsPluginOptions>;
     sayt?: SaytConfig;
+    search?: Partial<SearchPluginOptions>;
   }
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,2 +1,5 @@
-export default function quickStart(): void {
+import { Core } from '@groupby/elements-core';
+
+export default function quickStart(): Core {
+  return new Core();
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase, camelcase */
+
 import { CacheDriverPlugin, CacheDriverOptions } from '@groupby/elements-cache-driver-plugin';
 import { CachePlugin, CachePluginOptions } from '@groupby/elements-cache-plugin';
 import { Core } from '@groupby/elements-core';

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -93,7 +93,7 @@ export interface QuickStartOptions<P> {
     /** Options for the DOM Events plugin. */
     dom_events?: Partial<DomEventsPluginOptions>;
     /** Options for the SAYT plugin. */
-    sayt?: SaytConfig;
+    sayt?: SaytPluginOptions;
     /** Options for the SAYT Driver plugin. */
     sayt_driver?: Partial<SaytDriverOptions<P>>;
     /** Options for the Search plugin. */

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,5 +1,5 @@
 import { CacheDriverPlugin } from '@groupby/elements-cache-driver-plugin';
-import { CachePlugin } from '@groupby/elements-cache-plugin';
+import { CachePlugin, CachePluginOptions } from '@groupby/elements-cache-plugin';
 import { Core } from '@groupby/elements-core';
 import { DomEventsPlugin } from '@groupby/elements-dom-events-plugin';
 import { ProductTransformer } from '@groupby/elements-events';
@@ -9,12 +9,13 @@ import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin } from '@groupby/elements-search-plugin';
 
 export default function quickStart<P>({
+  cacheOptions,
   customerId,
   productTransformer,
 }: QuickStartOptions<P>): Core {
   const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin();
-  const cachePlugin = new CachePlugin();
+  const cachePlugin = new CachePlugin(cacheOptions);
   const domEventsPlugin = new DomEventsPlugin();
   const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
   const saytPlugin = new SaytPlugin({ subdomain: customerId });
@@ -35,6 +36,7 @@ export default function quickStart<P>({
 }
 
 export interface QuickStartOptions<P> {
+  cacheOptions?: Partial<CachePluginOptions>;
   customerId: string;
   productTransformer?: ProductTransformer<P>;
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -9,15 +9,17 @@ import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin } from '@groupby/elements-search-plugin';
 
 export default function quickStart<P>({
-  cacheOptions,
   customerId,
-  domEventsOptions,
   productTransformer,
+  pluginOptions: {
+    cache,
+    dom_events
+  } = {},
 }: QuickStartOptions<P>): Core {
   const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin();
-  const cachePlugin = new CachePlugin(cacheOptions);
-  const domEventsPlugin = new DomEventsPlugin(domEventsOptions);
+  const cachePlugin = new CachePlugin(cache);
+  const domEventsPlugin = new DomEventsPlugin(dom_events);
   const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
   const saytPlugin = new SaytPlugin({ subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
@@ -37,8 +39,10 @@ export default function quickStart<P>({
 }
 
 export interface QuickStartOptions<P> {
-  cacheOptions?: Partial<CachePluginOptions>;
   customerId: string;
-  domEventsOptions?: DomEventsPluginOptions;
   productTransformer?: ProductTransformer<P>;
+  pluginOptions?: {
+    cache?: Partial<CachePluginOptions>;
+    dom_events?: Partial<DomEventsPluginOptions>;
+  }
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -7,13 +7,13 @@ import { SaytPlugin } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin } from '@groupby/elements-search-plugin';
 
-export default function quickStart(): Core {
+export default function quickStart({ customerId }: QuickStartOptions): Core {
   const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin();
   const cachePlugin = new CachePlugin();
   const domEventsPlugin = new DomEventsPlugin();
   const saytDriverPlugin = new SaytDriverPlugin();
-  const saytPlugin = new SaytPlugin();
+  const saytPlugin = new SaytPlugin({ subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin();
   const searchPlugin = new SearchPlugin({} as any);
 
@@ -28,4 +28,8 @@ export default function quickStart(): Core {
   ]);
 
   return core;
+}
+
+export interface QuickStartOptions {
+  customerId: string;
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -1,7 +1,7 @@
 import { CacheDriverPlugin } from '@groupby/elements-cache-driver-plugin';
 import { CachePlugin, CachePluginOptions } from '@groupby/elements-cache-plugin';
 import { Core } from '@groupby/elements-core';
-import { DomEventsPlugin } from '@groupby/elements-dom-events-plugin';
+import { DomEventsPlugin, DomEventsPluginOptions } from '@groupby/elements-dom-events-plugin';
 import { ProductTransformer } from '@groupby/elements-events';
 import { SaytDriverPlugin } from '@groupby/elements-sayt-driver-plugin';
 import { SaytPlugin } from '@groupby/elements-sayt-plugin';
@@ -11,12 +11,13 @@ import { SearchPlugin } from '@groupby/elements-search-plugin';
 export default function quickStart<P>({
   cacheOptions,
   customerId,
+  domEventsOptions,
   productTransformer,
 }: QuickStartOptions<P>): Core {
   const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin();
   const cachePlugin = new CachePlugin(cacheOptions);
-  const domEventsPlugin = new DomEventsPlugin();
+  const domEventsPlugin = new DomEventsPlugin(domEventsOptions);
   const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
   const saytPlugin = new SaytPlugin({ subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
@@ -38,5 +39,6 @@ export default function quickStart<P>({
 export interface QuickStartOptions<P> {
   cacheOptions?: Partial<CachePluginOptions>;
   customerId: string;
+  domEventsOptions?: DomEventsPluginOptions;
   productTransformer?: ProductTransformer<P>;
 }

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -19,7 +19,7 @@ export default function quickStart<P>({
   const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
   const saytPlugin = new SaytPlugin({ subdomain: customerId });
   const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
-  const searchPlugin = new SearchPlugin({} as any);
+  const searchPlugin = new SearchPlugin({ customerId });
 
   core.register([
     cacheDriverPlugin,

--- a/packages/@groupby/elements-quickstart/src/quick-start.ts
+++ b/packages/@groupby/elements-quickstart/src/quick-start.ts
@@ -2,19 +2,23 @@ import { CacheDriverPlugin } from '@groupby/elements-cache-driver-plugin';
 import { CachePlugin } from '@groupby/elements-cache-plugin';
 import { Core } from '@groupby/elements-core';
 import { DomEventsPlugin } from '@groupby/elements-dom-events-plugin';
+import { ProductTransformer } from '@groupby/elements-events';
 import { SaytDriverPlugin } from '@groupby/elements-sayt-driver-plugin';
 import { SaytPlugin } from '@groupby/elements-sayt-plugin';
 import { SearchDriverPlugin } from '@groupby/elements-search-driver-plugin';
 import { SearchPlugin } from '@groupby/elements-search-plugin';
 
-export default function quickStart({ customerId }: QuickStartOptions): Core {
+export default function quickStart<P>({
+  customerId,
+  productTransformer,
+}: QuickStartOptions<P>): Core {
   const core = new Core();
   const cacheDriverPlugin = new CacheDriverPlugin();
   const cachePlugin = new CachePlugin();
   const domEventsPlugin = new DomEventsPlugin();
-  const saytDriverPlugin = new SaytDriverPlugin();
+  const saytDriverPlugin = new SaytDriverPlugin({ productTransformer });
   const saytPlugin = new SaytPlugin({ subdomain: customerId });
-  const searchDriverPlugin = new SearchDriverPlugin();
+  const searchDriverPlugin = new SearchDriverPlugin({ productTransformer });
   const searchPlugin = new SearchPlugin({} as any);
 
   core.register([
@@ -30,6 +34,7 @@ export default function quickStart({ customerId }: QuickStartOptions): Core {
   return core;
 }
 
-export interface QuickStartOptions {
+export interface QuickStartOptions<P> {
   customerId: string;
+  productTransformer?: ProductTransformer<P>;
 }

--- a/packages/@groupby/elements-quickstart/test/.eslintrc.js
+++ b/packages/@groupby/elements-quickstart/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/@groupby/elements-quickstart/test/setup.ts
+++ b/packages/@groupby/elements-quickstart/test/setup.ts
@@ -1,0 +1,1 @@
+import '../../../../test/setup';

--- a/packages/@groupby/elements-quickstart/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/index.test.ts
@@ -1,0 +1,17 @@
+import { AssertTypesEqual, expect } from '../../utils';
+import {
+  quickStart as quickStartExport,
+  QuickStartOptions as QuickStartOptionsExport,
+} from '../../../src';
+import quickStart, { QuickStartOptions } from '../../../src/quick-start';
+
+describe('Entry point', () => {
+  it('should export the quickStart function', () => {
+    expect(quickStartExport).to.equal(quickStart);
+  });
+
+  it('should export the QuickStartOptions interface', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const test: AssertTypesEqual<QuickStartOptions<{}>, QuickStartOptionsExport<{}>> = true;
+  });
+});

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -10,6 +10,7 @@ import { expect, spy, stub } from '../../utils';
 import quickStart from '../../../src/quick-start';
 
 describe('quickStart()', () => {
+  const customerId = 'custid';
   let CoreStub;
   let CachePlugin;
   let CacheDriverPlugin;
@@ -35,14 +36,14 @@ describe('quickStart()', () => {
   });
 
   it('should return an instance of Core', () => {
-    const returnedCore = quickStart();
+    const returnedCore = quickStart({ customerId });
 
     expect(CoreStub.calledWithNew()).to.be.true;
     expect(returnedCore).to.equal(core);
   });
 
   it('should instantiate plugins', () => {
-    quickStart();
+    quickStart({ customerId });
 
     expect(CachePlugin.calledWithNew()).to.be.true;
     expect(CacheDriverPlugin.calledWithNew()).to.be.true;
@@ -69,7 +70,7 @@ describe('quickStart()', () => {
     SearchPlugin.returns(searchPlugin);
     SearchDriverPlugin.returns(searchDriverPlugin);
 
-    quickStart();
+    quickStart({ customerId });
 
     const plugins = register.firstCall.args[0];
     expect(plugins).to.have.members([
@@ -83,7 +84,12 @@ describe('quickStart()', () => {
     ]);
   });
 
-  it('should forward customerId to SaytPlugin');
+  it('should forward customerId to SaytPlugin', () => {
+    quickStart({ customerId });
+
+    expect(SaytPlugin).to.be.calledWith({ subdomain: customerId });
+  });
+
   it('should forward productTransformer to SaytPlugin');
   it('should forward productTransformer to SearchPlugin');
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -126,6 +126,14 @@ describe('quickStart()', () => {
     expect(CachePlugin).to.be.calledWith(options);
   });
 
+  it.only('should forward options to the CacheDriverPlugin', () => {
+    const options = {};
+
+    quickStart({ customerId, pluginOptions: { cache_driver: options } });
+
+    expect(CacheDriverPlugin).to.be.calledWith(options);
+  });
+
   it('should forward dom event options to the DomEventsPlugin', () => {
     const window = stub();
     const CustomEvent = stub();

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -90,9 +90,19 @@ describe('quickStart()', () => {
     expect(SaytPlugin).to.be.calledWith({ subdomain: customerId });
   });
 
-  it('should forward productTransformer to SaytPlugin', () => {
+  it('should forward productTransformer to SaytDriverPlugin', () => {
+    const productTransformer = () => ({ a: 'a' });
 
+    quickStart({ customerId, productTransformer });
+
+    expect(SaytDriverPlugin).to.be.calledWith({ productTransformer });
   });
 
-  it('should forward productTransformer to SearchPlugin');
+  it('should forward productTransformer to SearchDriverPlugin', () => {
+    const productTransformer = () => ({ a: 'a' });
+
+    quickStart({ customerId, productTransformer });
+
+    expect(SearchDriverPlugin).to.be.calledWith({ productTransformer });
+  });
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -90,6 +90,12 @@ describe('quickStart()', () => {
     expect(SaytPlugin).to.be.calledWith({ subdomain: customerId });
   });
 
+  it('should forward customerId to SearchPlugin', () => {
+    quickStart({ customerId });
+
+    expect(SearchPlugin).to.be.calledWith({ customerId });
+  });
+
   it('should forward productTransformer to SaytDriverPlugin', () => {
     const productTransformer = () => ({ a: 'a' });
 

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -1,0 +1,9 @@
+import quickStart from '../../../src/quick-start';
+
+describe('quickStart()', () => {
+  it('should instantiate Core');
+  it('should registers plugins');
+  it('should forward customerId to SaytPlugin');
+  it('should forward productTransformer to SaytPlugin');
+  it('should forward productTransformer to SearchPlugin');
+});

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -22,6 +22,7 @@ describe('quickStart()', () => {
   let core;
   let register;
   let productTransformer;
+  let options: any;
 
   beforeEach(() => {
     register = spy();
@@ -35,6 +36,7 @@ describe('quickStart()', () => {
     SearchPlugin = stub(Search, 'SearchPlugin');
     SearchDriverPlugin = stub(SearchDriver, 'SearchDriverPlugin');
     productTransformer = stub();
+    options = { a: 'a' };
   });
 
   it('should return an instance of Core', () => {
@@ -87,16 +89,12 @@ describe('quickStart()', () => {
   });
 
   it('should forward customerId and options to the SaytPlugin', () => {
-    const options = { collection: 'collection' };
-
     quickStart({ customerId, pluginOptions: { sayt: options } });
 
     expect(SaytPlugin).to.be.calledWith({ ...options, subdomain: customerId });
   });
 
   it('should forward customerId and options to the SearchPlugin', () => {
-    const options = { https: true };
-
     quickStart({ customerId, pluginOptions: { search: options } });
 
     expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
@@ -109,7 +107,7 @@ describe('quickStart()', () => {
   });
 
   it('should forward options to the SaytDriverPlugin', () => {
-    const options = { productTransformer };
+    options.productTransformer = productTransformer;
 
     quickStart({ customerId, pluginOptions: { sayt_driver: options } });
 
@@ -118,7 +116,7 @@ describe('quickStart()', () => {
 
   it('should pass the productTransformer from the sayt driver options if it exists instead of the general one', () => {
     const optionsProductTransformer = stub();
-    const options = { productTransformer: optionsProductTransformer };
+    options.productTransformer = optionsProductTransformer;
 
     quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
 
@@ -133,7 +131,7 @@ describe('quickStart()', () => {
   });
 
   it('should forward options to the SearchDriverPlugin', () => {
-    const options = { productTransformer };
+    options.productTransformer = productTransformer;
 
     quickStart({ customerId, pluginOptions: { search_driver: options } });
 
@@ -142,7 +140,7 @@ describe('quickStart()', () => {
 
   it('should pass the productTransformer from the search driver options if it exists instead of the general one', () => {
     const optionsProductTransformer = stub();
-    const options = { productTransformer: optionsProductTransformer };
+    options.productTransformer = optionsProductTransformer;
 
     quickStart({ customerId, productTransformer, pluginOptions: { search_driver: options } });
 
@@ -151,26 +149,18 @@ describe('quickStart()', () => {
   });
 
   it('should forward cache options to the CachePlugin', () => {
-    const options = { store: new Map() };
-
     quickStart({ customerId, pluginOptions: { cache: options } });
 
     expect(CachePlugin).to.be.calledWith(options);
   });
 
   it('should forward options to the CacheDriverPlugin', () => {
-    const options = {};
-
     quickStart({ customerId, pluginOptions: { cache_driver: options } });
 
     expect(CacheDriverPlugin).to.be.calledWith(options);
   });
 
   it('should forward dom event options to the DomEventsPlugin', () => {
-    const window = stub();
-    const CustomEvent = stub();
-    const options = { window, CustomEvent };
-
     quickStart({ customerId, pluginOptions: { dom_events: options } });
 
     expect(DomEventsPlugin).to.be.calledWith(options);

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -116,6 +116,16 @@ describe('quickStart()', () => {
     expect(SaytDriverPlugin).to.be.calledWith(options);
   });
 
+  it('should pass the productTransformer from the sayt driver options if it exists instead of the general one', () => {
+    const optionsProductTransformer = stub();
+    const options = { productTransformer: optionsProductTransformer };
+
+    quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
+
+    expect(SaytDriverPlugin).to.be.calledWith(options);
+    expect(SaytDriverPlugin).to.not.be.calledWith(productTransformer);
+  });
+
   it('should forward productTransformer to SearchDriverPlugin', () => {
     quickStart({ customerId, productTransformer });
 
@@ -128,6 +138,16 @@ describe('quickStart()', () => {
     quickStart({ customerId, pluginOptions: { search_driver: options }})
 
     expect(SearchDriverPlugin).to.be.calledWith(options);
+  });
+
+  it('should pass the productTransformer from the search driver options if it exists instead of the general one', () => {
+    const optionsProductTransformer = stub();
+    const options = { productTransformer: optionsProductTransformer };
+
+    quickStart({ customerId, productTransformer, pluginOptions: { search_driver: options } });
+
+    expect(SearchDriverPlugin).to.be.calledWith(options);
+    expect(SearchDriverPlugin).to.not.be.calledWith(productTransformer);
   });
 
   it('should forward cache options to the CachePlugin', () => {

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -84,10 +84,12 @@ describe('quickStart()', () => {
     ]);
   });
 
-  it('should forward customerId to SaytPlugin', () => {
-    quickStart({ customerId });
+  it('should forward customerId and options to the SaytPlugin', () => {
+    const sayt = { collection: 'collection' };
+    
+    quickStart({ customerId, pluginOptions: { sayt } });
 
-    expect(SaytPlugin).to.be.calledWith({ subdomain: customerId });
+    expect(SaytPlugin).to.be.calledWith({ ...sayt, subdomain: customerId });
   });
 
   it('should forward customerId to SearchPlugin', () => {

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -21,6 +21,7 @@ describe('quickStart()', () => {
   let SearchDriverPlugin;
   let core;
   let register;
+  let productTransformer;
 
   beforeEach(() => {
     register = spy();
@@ -33,6 +34,7 @@ describe('quickStart()', () => {
     SaytDriverPlugin = stub(SaytDriver, 'SaytDriverPlugin');
     SearchPlugin = stub(Search, 'SearchPlugin');
     SearchDriverPlugin = stub(SearchDriver, 'SearchDriverPlugin');
+    productTransformer = stub();
   });
 
   it('should return an instance of Core', () => {
@@ -100,22 +102,32 @@ describe('quickStart()', () => {
     expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
   });
 
-  it('should forward options and productTransformer to SaytDriverPlugin', () => {
-    const productTransformer = () => ({ a: 'a' });
-    const options = { productTransformer };
+  it('should forward productTransformer to SaytDriverPlugin', () => {
+    quickStart({ customerId, productTransformer });
 
-    quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
-
-    expect(SaytDriverPlugin).to.be.calledWith({ ...options, productTransformer });
+    expect(SaytDriverPlugin).to.be.calledWith({ productTransformer });
   });
 
-  it('should forward options and productTransformer to SearchDriverPlugin', () => {
-    const productTransformer = () => ({ a: 'a' });
+  it('should forward options to the SaytDriverPlugin', () => {
     const options = { productTransformer };
 
-    quickStart({ customerId, productTransformer, pluginOptions: { search_driver: options } });
+    quickStart({ customerId, pluginOptions: { sayt_driver: options }})
+
+    expect(SaytDriverPlugin).to.be.calledWith(options);
+  });
+
+  it('should forward productTransformer to SearchDriverPlugin', () => {
+    quickStart({ customerId, productTransformer });
 
     expect(SearchDriverPlugin).to.be.calledWith({ productTransformer });
+  });
+
+  it('should forward options to the SearchDriverPlugin', () => {
+    const options = { productTransformer };
+
+    quickStart({ customerId, pluginOptions: { search_driver: options }})
+
+    expect(SearchDriverPlugin).to.be.calledWith(options);
   });
 
   it('should forward cache options to the CachePlugin', () => {
@@ -126,7 +138,7 @@ describe('quickStart()', () => {
     expect(CachePlugin).to.be.calledWith(options);
   });
 
-  it.only('should forward options to the CacheDriverPlugin', () => {
+  it('should forward options to the CacheDriverPlugin', () => {
     const options = {};
 
     quickStart({ customerId, pluginOptions: { cache_driver: options } });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -113,20 +113,20 @@ describe('quickStart()', () => {
   });
 
   it('should forward cache options to the CachePlugin', () => {
-    const cacheOptions = { store: new Map() };
+    const cache = { store: new Map() };
 
-    quickStart({ cacheOptions, customerId });
+    quickStart({ customerId, pluginOptions: { cache } });
 
-    expect(CachePlugin).to.be.calledWith( cacheOptions )
+    expect(CachePlugin).to.be.calledWith(cache);
   });
 
   it('should forward dom event options to the DomEventsPlugin', () => {
     const window = stub().returns(class Window{});
     const CustomEvent = stub();
-    const domEventsOptions = { window, CustomEvent };
+    const dom_events = { window, CustomEvent };
 
-    quickStart({ customerId, domEventsOptions });
+    quickStart({ customerId, pluginOptions: { dom_events } });
 
-    expect(DomEventsPlugin).to.be.calledWith( domEventsOptions )
+    expect(DomEventsPlugin).to.be.calledWith(dom_events);
   });
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -111,4 +111,12 @@ describe('quickStart()', () => {
 
     expect(SearchDriverPlugin).to.be.calledWith({ productTransformer });
   });
+
+  it('should forward cache options to the CachePlugin', () => {
+    const cacheOptions = { store: new Map() };
+
+    quickStart({ cacheOptions, customerId });
+
+    expect(CachePlugin).to.be.calledWith( cacheOptions )
+  });
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -1,7 +1,18 @@
+import * as Core from '@groupby/elements-core';
+import { expect, stub } from '../../utils';
 import quickStart from '../../../src/quick-start';
 
 describe('quickStart()', () => {
-  it('should instantiate Core');
+  it('should return an instance of Core', () => {
+    const core = { a: 'a' };
+    const CoreStub = stub(Core, 'Core').returns(core);
+
+    const returnedCore = quickStart();
+
+    expect(CoreStub.calledWithNew()).to.be.true;
+    expect(returnedCore).to.equal(core);
+  });
+
   it('should registers plugins');
   it('should forward customerId to SaytPlugin');
   it('should forward productTransformer to SaytPlugin');

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -103,16 +103,17 @@ describe('quickStart()', () => {
   it('should forward options and productTransformer to SaytDriverPlugin', () => {
     const productTransformer = () => ({ a: 'a' });
     const options = { productTransformer };
-
+    
     quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
-
+    
     expect(SaytDriverPlugin).to.be.calledWith({ ...options, productTransformer });
   });
-
-  it('should forward productTransformer to SearchDriverPlugin', () => {
+  
+  it('should forward options and productTransformer to SearchDriverPlugin', () => {
     const productTransformer = () => ({ a: 'a' });
+    const options = { productTransformer };
 
-    quickStart({ customerId, productTransformer });
+    quickStart({ customerId, productTransformer, pluginOptions: { search_driver: options } });
 
     expect(SearchDriverPlugin).to.be.calledWith({ productTransformer });
   });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -91,7 +91,9 @@ describe('quickStart()', () => {
   it('should forward customerId and options to the SaytPlugin', () => {
     quickStart({ customerId, pluginOptions: { sayt: options } });
 
-    expect(SaytPlugin).to.be.calledWith({ ...options, subdomain: customerId });
+    expect(SaytPlugin).to.be.calledWithExactly({ ...options, subdomain: customerId });
+  });
+
   it('should pass the customerId from the sayt plugin options if it exists instead of the general one', () => {
     options.subdomain = 'options custid';
 
@@ -103,7 +105,7 @@ describe('quickStart()', () => {
   it('should forward customerId and options to the SearchPlugin', () => {
     quickStart({ customerId, pluginOptions: { search: options } });
 
-    expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
+    expect(SearchPlugin).to.be.calledWithExactly({ ...options, customerId });
   });
 
   it('should pass the customerId from the search plugin options if it exists instead of the general one', () => {
@@ -117,13 +119,13 @@ describe('quickStart()', () => {
   it('should forward productTransformer to SaytDriverPlugin', () => {
     quickStart({ customerId, productTransformer });
 
-    expect(SaytDriverPlugin).to.be.calledWith({ productTransformer });
+    expect(SaytDriverPlugin).to.be.calledWithExactly({ productTransformer });
   });
 
   it('should forward options to the SaytDriverPlugin', () => {
     quickStart({ customerId, pluginOptions: { sayt_driver: options } });
 
-    expect(SaytDriverPlugin).to.be.calledWith(options);
+    expect(SaytDriverPlugin).to.be.calledWithExactly(options);
   });
 
   it('should pass the productTransformer from the sayt driver options if it exists instead of the general one', () => {
@@ -131,19 +133,19 @@ describe('quickStart()', () => {
 
     quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
 
-    expect(SaytDriverPlugin).to.be.calledWith(options);
+    expect(SaytDriverPlugin).to.be.calledWithExactly(options);
   });
 
   it('should forward productTransformer to SearchDriverPlugin', () => {
     quickStart({ customerId, productTransformer });
 
-    expect(SearchDriverPlugin).to.be.calledWith({ productTransformer });
+    expect(SearchDriverPlugin).to.be.calledWithExactly({ productTransformer });
   });
 
   it('should forward options to the SearchDriverPlugin', () => {
     quickStart({ customerId, pluginOptions: { search_driver: options } });
 
-    expect(SearchDriverPlugin).to.be.calledWith(options);
+    expect(SearchDriverPlugin).to.be.calledWithExactly(options);
   });
 
   it('should pass the productTransformer from the search driver options if it exists instead of the general one', () => {
@@ -151,25 +153,24 @@ describe('quickStart()', () => {
 
     quickStart({ customerId, productTransformer, pluginOptions: { search_driver: options } });
 
-    expect(SearchDriverPlugin).to.be.calledWith(options);
-    expect(SearchDriverPlugin).to.not.be.calledWith(productTransformer);
+    expect(SearchDriverPlugin).to.be.calledWithExactly(options);
   });
 
   it('should forward cache options to the CachePlugin', () => {
     quickStart({ customerId, pluginOptions: { cache: options } });
 
-    expect(CachePlugin).to.be.calledWith(options);
+    expect(CachePlugin).to.be.calledWithExactly(options);
   });
 
   it('should forward options to the CacheDriverPlugin', () => {
     quickStart({ customerId, pluginOptions: { cache_driver: options } });
 
-    expect(CacheDriverPlugin).to.be.calledWith(options);
+    expect(CacheDriverPlugin).to.be.calledWithExactly(options);
   });
 
   it('should forward dom event options to the DomEventsPlugin', () => {
     quickStart({ customerId, pluginOptions: { dom_events: options } });
 
-    expect(DomEventsPlugin).to.be.calledWith(options);
+    expect(DomEventsPlugin).to.be.calledWithExactly(options);
   });
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -100,12 +100,13 @@ describe('quickStart()', () => {
     expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
   });
 
-  it('should forward productTransformer to SaytDriverPlugin', () => {
+  it('should forward options and productTransformer to SaytDriverPlugin', () => {
     const productTransformer = () => ({ a: 'a' });
+    const options = { productTransformer };
 
-    quickStart({ customerId, productTransformer });
+    quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
 
-    expect(SaytDriverPlugin).to.be.calledWith({ productTransformer });
+    expect(SaytDriverPlugin).to.be.calledWith({ ...options, productTransformer });
   });
 
   it('should forward productTransformer to SearchDriverPlugin', () => {

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -111,7 +111,7 @@ describe('quickStart()', () => {
   it('should forward options to the SaytDriverPlugin', () => {
     const options = { productTransformer };
 
-    quickStart({ customerId, pluginOptions: { sayt_driver: options }})
+    quickStart({ customerId, pluginOptions: { sayt_driver: options } });
 
     expect(SaytDriverPlugin).to.be.calledWith(options);
   });
@@ -135,7 +135,7 @@ describe('quickStart()', () => {
   it('should forward options to the SearchDriverPlugin', () => {
     const options = { productTransformer };
 
-    quickStart({ customerId, pluginOptions: { search_driver: options }})
+    quickStart({ customerId, pluginOptions: { search_driver: options } });
 
     expect(SearchDriverPlugin).to.be.calledWith(options);
   });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -119,4 +119,14 @@ describe('quickStart()', () => {
 
     expect(CachePlugin).to.be.calledWith( cacheOptions )
   });
+
+  it('should forward dom event options to the DomEventsPlugin', () => {
+    const window = stub().returns(class Window{});
+    const CustomEvent = stub();
+    const domEventsOptions = { window, CustomEvent };
+
+    quickStart({ customerId, domEventsOptions });
+
+    expect(DomEventsPlugin).to.be.calledWith( domEventsOptions )
+  });
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -92,12 +92,26 @@ describe('quickStart()', () => {
     quickStart({ customerId, pluginOptions: { sayt: options } });
 
     expect(SaytPlugin).to.be.calledWith({ ...options, subdomain: customerId });
+  it('should pass the customerId from the sayt plugin options if it exists instead of the general one', () => {
+    options.subdomain = 'options custid';
+
+    quickStart({ customerId, pluginOptions: { sayt: options } });
+
+    expect(SaytPlugin).to.be.calledWithExactly(options);
   });
 
   it('should forward customerId and options to the SearchPlugin', () => {
     quickStart({ customerId, pluginOptions: { search: options } });
 
     expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
+  });
+
+  it('should pass the customerId from the search plugin options if it exists instead of the general one', () => {
+    options.customerId = 'options custid';
+
+    quickStart({ customerId, pluginOptions: { search: options } });
+
+    expect(SearchPlugin).to.be.calledWithExactly(options);
   });
 
   it('should forward productTransformer to SaytDriverPlugin', () => {

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -92,10 +92,12 @@ describe('quickStart()', () => {
     expect(SaytPlugin).to.be.calledWith({ ...sayt, subdomain: customerId });
   });
 
-  it('should forward customerId to SearchPlugin', () => {
-    quickStart({ customerId });
+  it('should forward customerId and options to the SearchPlugin', () => {
+    const search = { https: true };
+    
+    quickStart({ customerId, pluginOptions: { search } });
 
-    expect(SearchPlugin).to.be.calledWith({ customerId });
+    expect(SearchPlugin).to.be.calledWith({ ...search, customerId });
   });
 
   it('should forward productTransformer to SaytDriverPlugin', () => {

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -53,7 +53,36 @@ describe('quickStart()', () => {
     expect(SearchDriverPlugin.calledWithNew()).to.be.true;
   });
 
-  it('should registers plugins');
+  it('should register plugins', () => {
+    const cachePlugin = { cache: 'cache' };
+    const cacheDriverPlugin = { cacheDriver: 'cacheDriver' };
+    const domEventsPlugin = { domEvents: 'domEvents' };
+    const saytPlugin = { sayt: 'sayt' };
+    const saytDriverPlugin = { saytDriver: 'saytDriver' };
+    const searchPlugin = { search: 'search' };
+    const searchDriverPlugin = { searchDriver: 'searchDriver' };
+    CachePlugin.returns(cachePlugin);
+    CacheDriverPlugin.returns(cacheDriverPlugin);
+    DomEventsPlugin.returns(domEventsPlugin);
+    SaytPlugin.returns(saytPlugin);
+    SaytDriverPlugin.returns(saytDriverPlugin);
+    SearchPlugin.returns(searchPlugin);
+    SearchDriverPlugin.returns(searchDriverPlugin);
+
+    quickStart();
+
+    const plugins = register.firstCall.args[0];
+    expect(plugins).to.have.members([
+      cacheDriverPlugin,
+      cachePlugin,
+      domEventsPlugin,
+      saytDriverPlugin,
+      saytPlugin,
+      searchDriverPlugin,
+      searchPlugin,
+    ]);
+  });
+
   it('should forward customerId to SaytPlugin');
   it('should forward productTransformer to SaytPlugin');
   it('should forward productTransformer to SearchPlugin');

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -90,6 +90,9 @@ describe('quickStart()', () => {
     expect(SaytPlugin).to.be.calledWith({ subdomain: customerId });
   });
 
-  it('should forward productTransformer to SaytPlugin');
+  it('should forward productTransformer to SaytPlugin', () => {
+
+  });
+
   it('should forward productTransformer to SearchPlugin');
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -86,7 +86,7 @@ describe('quickStart()', () => {
 
   it('should forward customerId and options to the SaytPlugin', () => {
     const options = { collection: 'collection' };
-    
+
     quickStart({ customerId, pluginOptions: { sayt: options } });
 
     expect(SaytPlugin).to.be.calledWith({ ...options, subdomain: customerId });
@@ -94,7 +94,7 @@ describe('quickStart()', () => {
 
   it('should forward customerId and options to the SearchPlugin', () => {
     const options = { https: true };
-    
+
     quickStart({ customerId, pluginOptions: { search: options } });
 
     expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
@@ -103,12 +103,12 @@ describe('quickStart()', () => {
   it('should forward options and productTransformer to SaytDriverPlugin', () => {
     const productTransformer = () => ({ a: 'a' });
     const options = { productTransformer };
-    
+
     quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
-    
+
     expect(SaytDriverPlugin).to.be.calledWith({ ...options, productTransformer });
   });
-  
+
   it('should forward options and productTransformer to SearchDriverPlugin', () => {
     const productTransformer = () => ({ a: 'a' });
     const options = { productTransformer };

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -35,7 +35,7 @@ describe('quickStart()', () => {
     SaytDriverPlugin = stub(SaytDriver, 'SaytDriverPlugin');
     SearchPlugin = stub(Search, 'SearchPlugin');
     SearchDriverPlugin = stub(SearchDriver, 'SearchDriverPlugin');
-    productTransformer = stub();
+    productTransformer = spy();
     options = { a: 'a' };
   });
 
@@ -113,13 +113,11 @@ describe('quickStart()', () => {
   });
 
   it('should pass the productTransformer from the sayt driver options if it exists instead of the general one', () => {
-    const optionsProductTransformer = stub();
-    options.productTransformer = optionsProductTransformer;
+    options.productTransformer = spy();
 
     quickStart({ customerId, productTransformer, pluginOptions: { sayt_driver: options } });
 
     expect(SaytDriverPlugin).to.be.calledWith(options);
-    expect(SaytDriverPlugin).to.not.be.calledWith(productTransformer);
   });
 
   it('should forward productTransformer to SearchDriverPlugin', () => {
@@ -135,8 +133,7 @@ describe('quickStart()', () => {
   });
 
   it('should pass the productTransformer from the search driver options if it exists instead of the general one', () => {
-    const optionsProductTransformer = stub();
-    options.productTransformer = optionsProductTransformer;
+    options.productTransformer = spy();
 
     quickStart({ customerId, productTransformer, pluginOptions: { search_driver: options } });
 

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -127,7 +127,7 @@ describe('quickStart()', () => {
   });
 
   it('should forward dom event options to the DomEventsPlugin', () => {
-    const window = stub().returns(class Window{});
+    const window = stub();
     const CustomEvent = stub();
     const options = { window, CustomEvent };
 

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -85,19 +85,19 @@ describe('quickStart()', () => {
   });
 
   it('should forward customerId and options to the SaytPlugin', () => {
-    const sayt = { collection: 'collection' };
+    const options = { collection: 'collection' };
     
-    quickStart({ customerId, pluginOptions: { sayt } });
+    quickStart({ customerId, pluginOptions: { sayt: options } });
 
-    expect(SaytPlugin).to.be.calledWith({ ...sayt, subdomain: customerId });
+    expect(SaytPlugin).to.be.calledWith({ ...options, subdomain: customerId });
   });
 
   it('should forward customerId and options to the SearchPlugin', () => {
-    const search = { https: true };
+    const options = { https: true };
     
-    quickStart({ customerId, pluginOptions: { search } });
+    quickStart({ customerId, pluginOptions: { search: options } });
 
-    expect(SearchPlugin).to.be.calledWith({ ...search, customerId });
+    expect(SearchPlugin).to.be.calledWith({ ...options, customerId });
   });
 
   it('should forward productTransformer to SaytDriverPlugin', () => {
@@ -117,20 +117,20 @@ describe('quickStart()', () => {
   });
 
   it('should forward cache options to the CachePlugin', () => {
-    const cache = { store: new Map() };
+    const options = { store: new Map() };
 
-    quickStart({ customerId, pluginOptions: { cache } });
+    quickStart({ customerId, pluginOptions: { cache: options } });
 
-    expect(CachePlugin).to.be.calledWith(cache);
+    expect(CachePlugin).to.be.calledWith(options);
   });
 
   it('should forward dom event options to the DomEventsPlugin', () => {
     const window = stub().returns(class Window{});
     const CustomEvent = stub();
-    const dom_events = { window, CustomEvent };
+    const options = { window, CustomEvent };
 
-    quickStart({ customerId, pluginOptions: { dom_events } });
+    quickStart({ customerId, pluginOptions: { dom_events: options } });
 
-    expect(DomEventsPlugin).to.be.calledWith(dom_events);
+    expect(DomEventsPlugin).to.be.calledWith(options);
   });
 });

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -1,16 +1,56 @@
+import * as Cache from '@groupby/elements-cache-plugin';
+import * as CacheDriver from '@groupby/elements-cache-driver-plugin';
 import * as Core from '@groupby/elements-core';
-import { expect, stub } from '../../utils';
+import * as DomEvents from '@groupby/elements-dom-events-plugin';
+import * as Sayt from '@groupby/elements-sayt-plugin';
+import * as SaytDriver from '@groupby/elements-sayt-driver-plugin';
+import * as Search from '@groupby/elements-search-plugin';
+import * as SearchDriver from '@groupby/elements-search-driver-plugin';
+import { expect, spy, stub } from '../../utils';
 import quickStart from '../../../src/quick-start';
 
 describe('quickStart()', () => {
-  it('should return an instance of Core', () => {
-    const core = { a: 'a' };
-    const CoreStub = stub(Core, 'Core').returns(core);
+  let CoreStub;
+  let CachePlugin;
+  let CacheDriverPlugin;
+  let DomEventsPlugin;
+  let SaytPlugin;
+  let SaytDriverPlugin;
+  let SearchPlugin;
+  let SearchDriverPlugin;
+  let core;
+  let register;
 
+  beforeEach(() => {
+    register = spy();
+    core = { register };
+    CoreStub = stub(Core, 'Core').returns(core);
+    CachePlugin = stub(Cache, 'CachePlugin');
+    CacheDriverPlugin = stub(CacheDriver, 'CacheDriverPlugin');
+    DomEventsPlugin = stub(DomEvents, 'DomEventsPlugin');
+    SaytPlugin = stub(Sayt, 'SaytPlugin');
+    SaytDriverPlugin = stub(SaytDriver, 'SaytDriverPlugin');
+    SearchPlugin = stub(Search, 'SearchPlugin');
+    SearchDriverPlugin = stub(SearchDriver, 'SearchDriverPlugin');
+  });
+
+  it('should return an instance of Core', () => {
     const returnedCore = quickStart();
 
     expect(CoreStub.calledWithNew()).to.be.true;
     expect(returnedCore).to.equal(core);
+  });
+
+  it('should instantiate plugins', () => {
+    quickStart();
+
+    expect(CachePlugin.calledWithNew()).to.be.true;
+    expect(CacheDriverPlugin.calledWithNew()).to.be.true;
+    expect(DomEventsPlugin.calledWithNew()).to.be.true;
+    expect(SaytPlugin.calledWithNew()).to.be.true;
+    expect(SaytDriverPlugin.calledWithNew()).to.be.true;
+    expect(SearchPlugin.calledWithNew()).to.be.true;
+    expect(SearchDriverPlugin.calledWithNew()).to.be.true;
   });
 
   it('should registers plugins');

--- a/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
+++ b/packages/@groupby/elements-quickstart/test/unit/common/quick-start.test.ts
@@ -107,8 +107,6 @@ describe('quickStart()', () => {
   });
 
   it('should forward options to the SaytDriverPlugin', () => {
-    options.productTransformer = productTransformer;
-
     quickStart({ customerId, pluginOptions: { sayt_driver: options } });
 
     expect(SaytDriverPlugin).to.be.calledWith(options);
@@ -131,8 +129,6 @@ describe('quickStart()', () => {
   });
 
   it('should forward options to the SearchDriverPlugin', () => {
-    options.productTransformer = productTransformer;
-
     quickStart({ customerId, pluginOptions: { search_driver: options } });
 
     expect(SearchDriverPlugin).to.be.calledWith(options);

--- a/packages/@groupby/elements-quickstart/test/utils.ts
+++ b/packages/@groupby/elements-quickstart/test/utils.ts
@@ -1,0 +1,1 @@
+export * from '../../../../test/utils';

--- a/packages/@groupby/elements-quickstart/tsconfig.esnext.json
+++ b/packages/@groupby/elements-quickstart/tsconfig.esnext.json
@@ -1,0 +1,34 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.array.include",
+      "dom"
+    ],
+    "types": [
+      "node"
+    ],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "target": "es2015",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "esnext",
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "declaration": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/@groupby/elements-quickstart/tsconfig.json
+++ b/packages/@groupby/elements-quickstart/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.array.include",
+      "dom"
+    ],
+    "types": [
+      "node",
+      "mocha"
+    ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES5",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/@groupby/elements-sayt-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-sayt-driver-plugin/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- ELE-247: Exported `SaytDriverOptions` interface.
+
 ## [0.1.0] - 2019-11-28
 ### Added
 - SFX-160: Added the `SaytDriverPlugin` module.

--- a/packages/@groupby/elements-sayt-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-sayt-driver-plugin/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] [minor]
-### Added
-- ELE-247: Exported `SaytDriverOptions` interface.
+## [Unreleased] [patch]
+### Fixed
+- ELE-247: Exported the previously hidden `SaytDriverOptions` interface.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/packages/@groupby/elements-sayt-driver-plugin/src/index.ts
+++ b/packages/@groupby/elements-sayt-driver-plugin/src/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as SaytDriverPlugin } from './sayt-driver-plugin';
+export { default as SaytDriverPlugin, SaytDriverOptions } from './sayt-driver-plugin';

--- a/packages/@groupby/elements-sayt-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-sayt-driver-plugin/test/unit/common/index.test.ts
@@ -1,9 +1,14 @@
-import { expect } from '../../utils';
-import { SaytDriverPlugin as SaytDriverPluginExport } from '../../../src';
-import SaytDriverPlugin from '../../../src/sayt-driver-plugin';
+import { AssertTypesEqual, expect } from '../../utils';
+import { SaytDriverPlugin as SaytDriverPluginExport, SaytDriverOptions as SaytDriverOptionsExport } from '../../../src';
+import SaytDriverPlugin, { SaytDriverOptions } from '../../../src/sayt-driver-plugin';
 
 describe('Entry point', () => {
   it('should export the SaytDriverPlugin', () => {
     expect(SaytDriverPluginExport).to.equal(SaytDriverPlugin);
+  });
+
+  it('should export the SaytDriverOptions interface', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const test: AssertTypesEqual<SaytDriverOptionsExport<{}>, SaytDriverOptions<{}>> = true;
   });
 });

--- a/packages/@groupby/elements-sayt-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-sayt-plugin/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- ELE-247: Added `SaytOptions` interface.
+
+### Changed
+- ELE-247: Changed options intake interface from the imported `SaytConfig` to the extended `SaytOptions`.
+
 ## [0.1.0] - 2019-11-28
 ### Added
 - SFX-156: Added the `SaytPlugin` module.

--- a/packages/@groupby/elements-sayt-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-sayt-plugin/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] [minor]
-### Added
-- ELE-247: Added `SaytPluginOptions` interface.
-
+## [Unreleased] [patch]
 ### Changed
-- ELE-247: Changed options intake interface from the imported `SaytConfig` to the extended `SaytPluginOptions`.
+- ELE-247: Changed the type of the `SaytPlugin` options object to be `SaytPluginOptions` instead of `SaytConfig`.
+
+### Added
+- ELE-247: Added the `SaytPluginOptions` interface. It extends the `SaytConfig` interface.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/packages/@groupby/elements-sayt-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-sayt-plugin/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Added
-- ELE-247: Added `SaytOptions` interface.
+- ELE-247: Added `SaytPluginOptions` interface.
 
 ### Changed
-- ELE-247: Changed options intake interface from the imported `SaytConfig` to the extended `SaytOptions`.
+- ELE-247: Changed options intake interface from the imported `SaytConfig` to the extended `SaytPluginOptions`.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/packages/@groupby/elements-sayt-plugin/src/index.ts
+++ b/packages/@groupby/elements-sayt-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { default as SaytPlugin } from './sayt-plugin';
+export { default as SaytPlugin, SaytOptions } from './sayt-plugin';
 export * from 'sayt';

--- a/packages/@groupby/elements-sayt-plugin/src/index.ts
+++ b/packages/@groupby/elements-sayt-plugin/src/index.ts
@@ -1,2 +1,2 @@
-export { default as SaytPlugin, SaytOptions } from './sayt-plugin';
+export { default as SaytPlugin, SaytPluginOptions } from './sayt-plugin';
 export * from 'sayt';

--- a/packages/@groupby/elements-sayt-plugin/src/sayt-plugin.ts
+++ b/packages/@groupby/elements-sayt-plugin/src/sayt-plugin.ts
@@ -24,7 +24,7 @@ export default class SaytPlugin implements Plugin {
    *
    * @param options The options to instantiate the sayt client with.
    */
-  constructor(options?: SaytOptions) {
+  constructor(options?: SaytPluginOptions) {
     this.sayt = new Sayt(options);
   }
 
@@ -37,4 +37,4 @@ export default class SaytPlugin implements Plugin {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SaytOptions extends SaytConfig {}
+export interface SaytPluginOptions extends SaytConfig {}

--- a/packages/@groupby/elements-sayt-plugin/src/sayt-plugin.ts
+++ b/packages/@groupby/elements-sayt-plugin/src/sayt-plugin.ts
@@ -24,7 +24,7 @@ export default class SaytPlugin implements Plugin {
    *
    * @param options The options to instantiate the sayt client with.
    */
-  constructor(options?: SaytConfig) {
+  constructor(options?: SaytOptions) {
     this.sayt = new Sayt(options);
   }
 
@@ -35,3 +35,6 @@ export default class SaytPlugin implements Plugin {
     return this.sayt;
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SaytOptions extends SaytConfig {}

--- a/packages/@groupby/elements-sayt-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-sayt-plugin/test/unit/common/index.test.ts
@@ -1,14 +1,14 @@
 import { AssertTypesEqual, expect } from '../../utils';
-import SaytPlugin, { SaytOptions } from '../../../src/sayt-plugin';
-import { SaytPlugin as SaytExport, SaytOptions as SaytOptionsExport } from '../../../src/index';
+import SaytPlugin, { SaytPluginOptions } from '../../../src/sayt-plugin';
+import { SaytPlugin as SaytExport, SaytPluginOptions as SaytPluginOptionsExport } from '../../../src/index';
 
 describe('Entry point', () => {
   it('should export SaytPlugin', () => {
     expect(SaytPlugin).to.equal(SaytExport);
   });
 
-  it('should export the SaytOptions interface', () => {
+  it('should export the SaytPluginOptions interface', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const test: AssertTypesEqual<SaytOptionsExport, SaytOptions> = true;
+    const test: AssertTypesEqual<SaytPluginOptionsExport, SaytPluginOptions> = true;
   });
 });

--- a/packages/@groupby/elements-sayt-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-sayt-plugin/test/unit/common/index.test.ts
@@ -1,9 +1,14 @@
-import { expect } from '../../utils';
-import SaytPlugin from '../../../src/sayt-plugin';
-import { SaytPlugin as SaytExport } from '../../../src/index';
+import { AssertTypesEqual, expect } from '../../utils';
+import SaytPlugin, { SaytOptions } from '../../../src/sayt-plugin';
+import { SaytPlugin as SaytExport, SaytOptions as SaytOptionsExport } from '../../../src/index';
 
 describe('Entry point', () => {
   it('should export SaytPlugin', () => {
     expect(SaytPlugin).to.equal(SaytExport);
+  });
+
+  it('should export the SaytOptions interface', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const test: AssertTypesEqual<SaytOptionsExport, SaytOptions> = true;
   });
 });

--- a/packages/@groupby/elements-search-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-search-driver-plugin/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] [minor]
-### Added
-- ELE-247: Exported `SearchDriverOptions` interface.
+## [Unreleased] [patch]
+### Fixed
+- ELE-247: Exported the previously hidden `SearchDriverOptions` interface.
 
 ## [0.1.0] - 2019-11-28
 ### Added

--- a/packages/@groupby/elements-search-driver-plugin/CHANGELOG.md
+++ b/packages/@groupby/elements-search-driver-plugin/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- ELE-247: Exported `SearchDriverOptions` interface.
+
 ## [0.1.0] - 2019-11-28
 ### Added
 - SFX-159: Added the `SearchDriverPlugin` module.

--- a/packages/@groupby/elements-search-driver-plugin/src/index.ts
+++ b/packages/@groupby/elements-search-driver-plugin/src/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as SearchDriverPlugin } from './search-driver-plugin';
+export { default as SearchDriverPlugin, SearchDriverOptions } from './search-driver-plugin';

--- a/packages/@groupby/elements-search-driver-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-search-driver-plugin/test/unit/common/index.test.ts
@@ -1,9 +1,17 @@
-import { expect } from '../../utils';
-import SearchDriverPlugin from '../../../src/search-driver-plugin';
-import { SearchDriverPlugin as SearchDriverExport } from '../../../src/index';
+import { AssertTypesEqual, expect } from '../../utils';
+import SearchDriverPlugin, { SearchDriverOptions } from '../../../src/search-driver-plugin';
+import {
+  SearchDriverPlugin as SearchDriverExport,
+  SearchDriverOptions as SearchDriverOptionsExport,
+} from '../../../src/index';
 
 describe('Entry point', () => {
   it('should export SearchDriverPlugin', () => {
     expect(SearchDriverExport).to.equal(SearchDriverPlugin);
+  });
+
+  it('should export the SearchDriverOptions interface', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const test: AssertTypesEqual<SearchDriverOptionsExport<{}>, SearchDriverOptions<{}>> = true;
   });
 });

--- a/packages/@groupby/elements-search-plugin/test/unit/common/index.test.ts
+++ b/packages/@groupby/elements-search-plugin/test/unit/common/index.test.ts
@@ -1,5 +1,4 @@
 import { AssertTypesEqual, expect } from '../../utils';
-// eslint-disable-next-line
 import SearchPlugin, { SearchPluginExposedValue, SearchPluginOptions } from '../../../src/search-plugin';
 import {
   SearchPlugin as SearchPluginExport,

--- a/presets/all-plugins.ts
+++ b/presets/all-plugins.ts
@@ -1,2 +1,3 @@
 export * from './core';
 export * from './plugins';
+export * from '@groupby/elements-quickstart';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,10 @@ module.exports = {
       use: { loader: 'expose-loader', options: 'GbElementsPlugins' }
     },
     {
+      test: path.resolve(__dirname, 'presets', 'all-plugins.ts'),
+      use: { loader: 'expose-loader', options: 'GbElementsLogic' }
+    },
+    {
       test: /\.tsx?$/,
       loader: 'ts-loader',
       exclude: [/node_modules/]


### PR DESCRIPTION
A new package, `@groupby/elements-quickstart`, creates an instance of `Core` and registers all the plugins on it. The plugins are configurable through an options object accepted by the `quickStart` function.

A new global is exposed by Webpack, `GbElementsLogic`, that contains the `quickStart` function and all the other Logic layer entities.